### PR TITLE
Fix missing  std_srvs dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
 	roscpp
 	rospy
 	sensor_msgs
+	std_srvs
 	)
 
 ##################LaserFan ##########################
@@ -40,7 +41,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(CATKIN_DEPENDS
-	roscpp rospy sensor_msgs message_runtime
+	roscpp rospy sensor_msgs message_runtime std_srvs
 	)
 #---------------------------------------------------------------------------------------
 # Set default build to release

--- a/package.xml
+++ b/package.xml
@@ -53,16 +53,19 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
 
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
   <build_export_depend>message_generation</build_export_depend>
+  <build_export_depend>std_srvs</build_export_depend>
 
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->


### PR DESCRIPTION
Fixes the missing std_srvs dependency:
``fatal error: std_srvs/Empty.h: No such file or directory #include "std_srvs/Empty.h"``